### PR TITLE
Aliceverc/feature/add color to theme

### DIFF
--- a/Approach.md
+++ b/Approach.md
@@ -2,4 +2,5 @@ Approach:
 
 1. Create a useState hook in App.jsx that holds the array of colors > once the colors are in state, we can afterwards call a setter from the form and see the new card appear. Without state we'd have nowhere to "push" the newly entered color.
 
-2.
+2. Create an empty form component 'ColorForm.jsx' and give the form its own little memory and one role input. React re-renders the UI based on state: if the state never changes, nothing on the screen can react to what the user typed > we must store the most recent text in state to make an input controlled:
+    * make the 'role' input controlled (build a new state object on every keystroke instead of mutating the old one) > typing in the 'role' field now updates formValues.role in real time.

--- a/Approach.md
+++ b/Approach.md
@@ -1,0 +1,5 @@
+Approach:
+
+1. Create a useState hook in App.jsx that holds the array of colors > once the colors are in state, we can afterwards call a setter from the form and see the new card appear. Without state we'd have nowhere to "push" the newly entered color.
+
+2.

--- a/Approach.md
+++ b/Approach.md
@@ -1,6 +1,10 @@
-Approach:
+# Approach:
 
 1. Create a useState hook in App.jsx that holds the array of colors > once the colors are in state, we can afterwards call a setter from the form and see the new card appear. Without state we'd have nowhere to "push" the newly entered color.
 
 2. Create an empty form component 'ColorForm.jsx' and give the form its own little memory and one role input. React re-renders the UI based on state: if the state never changes, nothing on the screen can react to what the user typed > we must store the most recent text in state to make an input controlled:
     * make the 'role' input controlled (build a new state object on every keystroke instead of mutating the old one) > typing in the 'role' field now updates formValues.role in real time.
+    * create the 'ColorInput' component > a reusable 'ColorInput' shows two linked input. Changing either one updates the other and notifies the parent via onChange: 
+        * a small colour-picker (type="color")
+        * a hex text box
+   

--- a/Approach.md
+++ b/Approach.md
@@ -1,10 +1,29 @@
-# Approach:
+# Approach
 
-1. Create a useState hook in App.jsx that holds the array of colors > once the colors are in state, we can afterwards call a setter from the form and see the new card appear. Without state we'd have nowhere to "push" the newly entered color.
+### 1. Lifted the colour list into React stateFile: App.jsx – lets the palette grow dynamically
 
-2. Create an empty form component 'ColorForm.jsx' and give the form its own little memory and one role input. React re-renders the UI based on state: if the state never changes, nothing on the screen can react to what the user typed > we must store the most recent text in state to make an input controlled:
-    * make the 'role' input controlled (build a new state object on every keystroke instead of mutating the old one) > typing in the 'role' field now updates formValues.role in real time.
-    * create the 'ColorInput' component > a reusable 'ColorInput' shows two linked input. Changing either one updates the other and notifies the parent via onChange: 
-        * a small colour-picker (type="color")
-        * a hex text box
-   
+Create a useState hook in App.jsx that holds the array of colors > once the colors are in state, we can afterwards call a setter from the form and see the new card appear. Without state we'd have nowhere to "push" the newly entered color.
+
+### 2. Stubbed a form component (ColorForm)
+
+Create an empty form component 'ColorForm.jsx' and give the form its own little memory and one role input. React re-renders the UI based on state: if the state never changes, nothing on the screen can react to what the user typed > we must store the most recent text in state to make an input controlled:
+
+### 3. Added local form state and controlled Role input
+
+- make the 'role' input controlled (build a new state object on every keystroke instead of mutating the old one) > typing in the 'role' field now updates formValues.role in real time.
+
+### 4. Introduced reusable ColorInput and wired it for Hex & ContrastText
+
+- create the 'ColorInput' component > a reusable 'ColorInput' shows two linked input. Changing either one updates the other and notifies the parent via onChange:
+  - a small colour-picker (type="color")
+  - a hex text box
+
+### 5. Implemented the 'Add' Button flow
+
+- create a button. You don't need to create a separate component. Here is how it will work:
+  - a color object is handed up to 'App.jsx'
+  - the submit handler gathers the current Role / Hex / ContrastTex values
+  - it wraps them (pluse some unique id value) in a plain object
+  - it calls the function that 'App' passed down (onAddColor) and gives it that object
+  - 'App.jsx' inserts the new object at the top f its 'colors' state > React re-renders, so a fresh colour card appears at the very top of the list
+  - the form resets to its default values

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@octokit/rest": "^20.1.0",
         "dotenv": "^16.4.5",
+        "nanoid": "^5.1.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -3365,21 +3366,21 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -3646,6 +3647,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@octokit/rest": "^20.1.0",
     "dotenv": "^16.4.5",
+    "nanoid": "^5.1.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,22 @@
 import { initialColors } from "./lib/colors";
 import Color from "./Components/Color/Color";
+import { useState } from "react";
+import { ColorForm } from "./Components/ColorForm/ColorForm";
 import "./App.css";
 
 function App() {
+  // call a useState hook and define 'initialColors' as the initial value
+  // set 'colors' as current state and 'setColors' as set function inside the variable
+  const [colors, setColors] = useState(initialColors);
+
   return (
     <>
       <h1>Theme Creator</h1>
 
-      {initialColors.map((color) => {
+      <ColorForm />
+
+      {/* swap 'initialColors.map' for 'colors.map' so the UI always reflects the latest state */}
+      {colors.map((color) => {
         return <Color key={color.id} color={color} />;
       })}
     </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,11 +9,18 @@ function App() {
   // set 'colors' as current state and 'setColors' as set function inside the variable
   const [colors, setColors] = useState(initialColors);
 
+  // callback passed to 'ColorForm' > prepends the new color so the newest entry shows first
+  function handleAddColor(newColor) {
+    // immutable update: create a brand-new array [newColor, ...colors]
+    setColors([newColor, ...colors]);
+  }
+
   return (
     <>
       <h1>Theme Creator</h1>
 
-      <ColorForm />
+      {/* pass down the add-callback so the form can hand new colors up */}
+      <ColorForm onAddColor={handleAddColor} />
 
       {/* swap 'initialColors.map' for 'colors.map' so the UI always reflects the latest state */}
       {colors.map((color) => {

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { ColorInput } from "../ColorInput/ColorInput";
+import { ContrastText } from "../ContrastText/ContrastText";
 
 // ColorForm.jsx
 // A controlled form that collects role, hex and contrastText for a new theme colour
@@ -33,6 +35,32 @@ export function ColorForm() {
               console.log(formValues);
             }}
           ></input>
+          <label>
+            Hex:
+            {/* pass the current hex from state; when child reports a change, copy existing state and overwrite hex only */}
+            <ColorInput
+              value={formValues.hex}
+              onChange={(newHex) =>
+                setFormValues({
+                  ...formValues,
+                  hex: newHex,
+                })
+              }
+            />
+          </label>
+        </label>
+        <label>
+          Contrast text:
+          {/* pass the current hex from state; when child reports a change, copy existing state and overwrite hex only */}
+          <ContrastText
+            value={formValues.contrastText}
+            onChange={(newContrast) =>
+              setFormValues({
+                ...formValues,
+                contrastText: newContrast,
+              })
+            }
+          />
         </label>
       </form>
     </>

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -1,0 +1,9 @@
+export function ColorForm() {
+  return (
+    <>
+      <form>
+        <h2>Add color</h2>
+      </form>
+    </>
+  );
+}

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -1,8 +1,35 @@
+import { useState } from "react";
+
 export function ColorForm() {
+  // use the useState hook to call an object with default vcalues 'role', 'hex' and 'contrastText'
+  // assign the 'role' value inside the <imput> tag of the 'role' text-field > {formValues.role} and
+  const [formValues, setFormValues] = useState({
+    role: "primary main",
+    hex: "#000000",
+    contrastText: "#FFFFFF",
+  });
+
   return (
     <>
       <form>
         <h2>Add color</h2>
+        <label>
+          Role:
+          <input
+            type="text"
+            name="role"
+            value={formValues.role}
+            onChange={(event) => {
+              const latestText = event.target.value;
+              const updatedState = {
+                ...formValues,
+                role: latestText,
+              };
+              setFormValues(updatedState);
+              console.log(formValues);
+            }}
+          ></input>
+        </label>
       </form>
     </>
   );

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { ColorInput } from "../ColorInput/ColorInput";
 import { ContrastText } from "../ContrastText/ContrastText";
+import { nanoid } from "nanoid";
 
 // ColorForm.jsx
 // A controlled form that collects role, hex and contrastText for a new theme colour
-export function ColorForm() {
+export function ColorForm({ onAddColor }) {
   // use the useState hook to call an object with default values 'role', 'hex' and 'contrastText'
   // assign the 'role' value inside the <input> tag of the 'role' text-field > {formValues.role}
   const [formValues, setFormValues] = useState({
@@ -13,9 +14,33 @@ export function ColorForm() {
     contrastText: "#FFFFFF",
   });
 
+  const handleSubmit = (event) => {
+    event.preventDefault(); // stop full-page reload
+
+    // build the new color object
+    const newColor = {
+      ...formValues, // role, hex, contrastText
+      id: nanoid(), // atatch a unique id
+    };
+    console.log(newColor);
+
+    // tell the parent component
+    onAddColor(newColor);
+
+    // clear the form for the next entry
+    setFormValues({
+      role: "primary main",
+      hex: "#000000",
+      contrastText: "#FFFFFF",
+    });
+  };
+
   return (
     <>
-      <form>
+      <form onSubmit={handleSubmit}>
+        {" "}
+        {/* whole form submits via handleSubmit > the Add button just triggers this */}
+        {/* return fields to sensible defaults so the user can add another coour quickly */}
         <h2>Add color</h2>
         <label htmlFor="role-input">
           Role:
@@ -32,7 +57,6 @@ export function ColorForm() {
                 role: latestText,
               };
               setFormValues(updatedState);
-              console.log(formValues);
             }}
           ></input>
           <label>
@@ -62,6 +86,7 @@ export function ColorForm() {
             }
           />
         </label>
+        <button type="submit">Add</button>
       </form>
     </>
   );

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 
+// ColorForm.jsx
+// A controlled form that collects role, hex and contrastText for a new theme colour
 export function ColorForm() {
-  // use the useState hook to call an object with default vcalues 'role', 'hex' and 'contrastText'
-  // assign the 'role' value inside the <imput> tag of the 'role' text-field > {formValues.role} and
+  // use the useState hook to call an object with default values 'role', 'hex' and 'contrastText'
+  // assign the 'role' value inside the <input> tag of the 'role' text-field > {formValues.role}
   const [formValues, setFormValues] = useState({
     role: "primary main",
     hex: "#000000",
@@ -13,12 +15,14 @@ export function ColorForm() {
     <>
       <form>
         <h2>Add color</h2>
-        <label>
+        <label htmlFor="role-input">
           Role:
           <input
+            id="role-input"
             type="text"
             name="role"
             value={formValues.role}
+            // copy-and-replace pattern: rebuild the whole object, changing only the field that just changed
             onChange={(event) => {
               const latestText = event.target.value;
               const updatedState = {

--- a/src/Components/ColorInput/ColorInput.jsx
+++ b/src/Components/ColorInput/ColorInput.jsx
@@ -1,0 +1,24 @@
+export function ColorInput({ value, onChange }) {
+  // value > current hex string; onChange > callback that receives the new hex string
+
+  // a pair of inputs (pciker + text) that always show the same hex value and report changes upward
+  return (
+    <div>
+      <label>
+        {/* two inputs share the same 'value' so they stay in sync */}
+        <input
+          type="color"
+          value={value}
+          onChange={(event) =>
+            onChange(event.target.value)
+          } /* forward just event.target.value (the hex) from the parent */
+        ></input>
+        <input
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        ></input>
+      </label>
+    </div>
+  );
+}

--- a/src/Components/ContrastText/ContrastText.jsx
+++ b/src/Components/ContrastText/ContrastText.jsx
@@ -1,0 +1,18 @@
+export function ContrastText({ value, onChange }) {
+  return (
+    <div>
+      <label>
+        <input
+          type="color"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        ></input>
+        <input
+          type="text"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        ></input>
+      </label>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,7 @@ https://www.joshwcomeau.com/css/custom-css-reset/
 body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  margin: 4%;
 }
 /*
   5. Improve media defaults


### PR DESCRIPTION
Acceptance Criteria (all met):
- Users can input a role, hex value, and contrast text via a form to add a new color to the theme.
- The form should be prefilled with default values to guide user input.
- Upon submission, the new color is added to the top of the colors and is displayed on a color card to confirm addition.
- The inputs for hex and contrastText should include both color and text input types for easy and accurate color selection.

Tasks Completed:
- Built a 'ColorForm' component to collect and submit new colours.
- Created a reusable 'ColorInput' component that keeps a colour-picker and text input in sync (controlled inputs).
- Duplicated that pattern for 'ContrastText'.
- Integrated the nanoid package to generate unique ids.
- Added an Add button that submits the form and updates the palette state.