### PR TITLE
persist theme in localStorage

### DIFF
--- a/Approach.md
+++ b/Approach.md
@@ -62,3 +62,13 @@ Before showing a form inside the card, add a little local flag saying "this card
   - if 'isEditing' is true, render the 'ColorForm' conmponent instead. Otherwise, render the normal card view (what you have now);
   - the form needs to start prefilled with this card's current values. So give it props like 'initialRole={color.role}', 'initialHex={color.hex}', 'initialContrastText={color.contrastText}
   - pass in the callbacks for saving ot canceling: 1. onSave(updateColor) > you'll call your parent's onDelete/onAdd combination or a new onEdit handler later 2. onCancel() > simply calls setIsEditing(false) to revert
+
+### 8. Persist theme in localStorage
+
+Before touching any code, let's get the helper installed:
+- run the package manager's install command for the local-storage hook: npm install use-local-storage-state
+
+That will give a drop-in replacement for useState that persists into localStorage.
+
+- Import the hook: at the top of 'Add.jsx', add an import for the new package's default export (useLocalStorageState)
+- Replace useState with the local-storage hook with two arguments: 1. a storage key string ('theme-colors'), 2. an options object that sets 'defaultValue' to 'initialColors' > on first load, ir will read from 'localStorage["theme-colors"]'; if nothing's there, it falls back to 'initialColors'. Any time you call 'setColors', it both updates React state and writes the new array into localStorage under that key

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "dotenv": "^16.4.5",
         "nanoid": "^5.1.5",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "use-local-storage-state": "^19.5.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -4327,6 +4328,22 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-local-storage-state": {
+      "version": "19.5.0",
+      "resolved": "https://registry.npmjs.org/use-local-storage-state/-/use-local-storage-state-19.5.0.tgz",
+      "integrity": "sha512-sUJAyFvsmqMpBhdwaRr7GTKkkoxb6PWeNVvpBDrLuwQF1PpbJRKIbOYeLLeqJI7B3wdfFlLLCBbmOdopiSTBOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/astoilkov"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "dotenv": "^16.4.5",
     "nanoid": "^5.1.5",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "use-local-storage-state": "^19.5.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,11 +4,14 @@ import { useState } from "react";
 import { ColorForm } from "./Components/ColorForm/ColorForm";
 import "./App.css";
 import "./global.css";
+import useLocalStorageState from "use-local-storage-state";
 
 function App() {
   // call a useState hook and define 'initialColors' as the initial value
   // set 'colors' as current state and 'setColors' as set function inside the variable
-  const [colors, setColors] = useState(initialColors);
+  const [colors, setColors] = useLocalStorageState("theme-colors", {
+    defaultValue: initialColors,
+  });
 
   // callback passed to 'ColorForm' > prepends the new color so the newest entry shows first
   function handleAddColor(newColor) {
@@ -38,7 +41,7 @@ function App() {
 
   return (
     <>
-      <h1>Color Theme Creator</h1>
+      <h1>🫟 Color Theme Creator</h1>
 
       {/* unified form for adding colors: calls handleAddColor via onsave */}
       <ColorForm onSave={handleAddColor} />

--- a/src/global.css
+++ b/src/global.css
@@ -1,5 +1,5 @@
 :root {
-  --violet: rgb(96, 74, 218);
-  --lightviolet: rgb(119, 100, 221);
+  --violet: #952bf1;
+  --lightviolet: #b36eee;
   --lightblue: rgba(202, 206, 252, 0.258);
 }


### PR DESCRIPTION
Acceptance Criteria:
- The theme is saved to localStorage upon any addition, deletion, or edit of a color.
- Upon reloading the application, the theme is retrieved and displayed from localStorage.

Tasks:
- Install use-local-storage-state package from npm npm i use-local-storage-state and use it
